### PR TITLE
Embed calendly with expo web browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-navigation/native": "^6.0.4",
         "expo": "~42.0.0",
         "expo-status-bar": "~1.0.4",
+        "expo-web-browser": "^10.0.3",
         "firebase": "8.2.3",
         "react": "16.13.1",
         "react-dom": "16.13.1",
@@ -4707,6 +4708,17 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
+    "node_modules/compare-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-urls/-/compare-urls-2.0.0.tgz",
+      "integrity": "sha512-eCJcWn2OYFEIqbm70ta7LQowJOOZZqq1a2YbbFCFI1uwSvj+TWMwXVn7vPR1ceFNcAIt5RSTDbwdlX82gYLTkA==",
+      "dependencies": {
+        "normalize-url": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/compare-versions": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
@@ -6613,6 +6625,24 @@
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.0.4.tgz",
       "integrity": "sha512-s7nc496D/Zn1NGiMJ5wu6HyIdXxbgGtmZZtbHm7rpbcmLdf28GmMSNHDx7M0t00BMhky7VAurTCUo+BJs8ugsw=="
     },
+    "node_modules/expo-web-browser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-10.0.3.tgz",
+      "integrity": "sha512-Tvx4yk7aROS6Yzy9obBMpcwtmIl2NY8YIOCUo1HwCB8KwTN7gQBKvI/GSOVYPMeIx/nPRg3ySELlUpv9JoGNag==",
+      "dependencies": {
+        "compare-urls": "^2.0.0",
+        "expo-modules-core": "~0.4.4"
+      }
+    },
+    "node_modules/expo-web-browser/node_modules/expo-modules-core": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.4.7.tgz",
+      "integrity": "sha512-boEbB3tAYO7WkgcaXToQLY8IUeEGOZeDF+StTL38FA0l8jzJwwQLU7TaWjWEMGfxvvn7KP7V7kFudJKc7dak3g==",
+      "dependencies": {
+        "compare-versions": "^3.4.0",
+        "invariant": "^2.2.4"
+      }
+    },
     "node_modules/expo/node_modules/@jest/types": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
@@ -7904,6 +7934,14 @@
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9383,6 +9421,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "dependencies": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-url/node_modules/query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url/node_modules/strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -10028,6 +10100,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prettier": {
@@ -11349,6 +11429,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/source-map": {
@@ -16162,6 +16253,14 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
+    "compare-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-urls/-/compare-urls-2.0.0.tgz",
+      "integrity": "sha512-eCJcWn2OYFEIqbm70ta7LQowJOOZZqq1a2YbbFCFI1uwSvj+TWMwXVn7vPR1ceFNcAIt5RSTDbwdlX82gYLTkA==",
+      "requires": {
+        "normalize-url": "^2.0.1"
+      }
+    },
     "compare-versions": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
@@ -17713,6 +17812,26 @@
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.0.4.tgz",
       "integrity": "sha512-s7nc496D/Zn1NGiMJ5wu6HyIdXxbgGtmZZtbHm7rpbcmLdf28GmMSNHDx7M0t00BMhky7VAurTCUo+BJs8ugsw=="
     },
+    "expo-web-browser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-10.0.3.tgz",
+      "integrity": "sha512-Tvx4yk7aROS6Yzy9obBMpcwtmIl2NY8YIOCUo1HwCB8KwTN7gQBKvI/GSOVYPMeIx/nPRg3ySELlUpv9JoGNag==",
+      "requires": {
+        "compare-urls": "^2.0.0",
+        "expo-modules-core": "~0.4.4"
+      },
+      "dependencies": {
+        "expo-modules-core": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.4.7.tgz",
+          "integrity": "sha512-boEbB3tAYO7WkgcaXToQLY8IUeEGOZeDF+StTL38FA0l8jzJwwQLU7TaWjWEMGfxvvn7KP7V7kFudJKc7dak3g==",
+          "requires": {
+            "compare-versions": "^3.4.0",
+            "invariant": "^2.2.4"
+          }
+        }
+      }
+    },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -18675,6 +18794,11 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -19886,6 +20010,33 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        }
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -20352,6 +20503,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
       "version": "2.4.1",
@@ -21385,6 +21541,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native": "^6.0.4",
     "expo": "~42.0.0",
     "expo-status-bar": "~1.0.4",
+    "expo-web-browser": "^10.0.3",
     "firebase": "8.2.3",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/screens/ScheduleScreen.tsx
+++ b/screens/ScheduleScreen.tsx
@@ -1,11 +1,25 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import { Button, Text, View } from 'react-native';
 import { screenStyles } from './HomeScreen';
 
 const ScheduleScreen = () => {
+  const [calendlyLink, setCalendlyLink] = useState<string>('');
+  useEffect(() => {
+    // get calendly link of attourney or attournies (round robin all attourneys for given case type)
+    setCalendlyLink(
+      'https://calendly.com/team-siren/round-robin-meeting-w-siren',
+    );
+  });
+
+  const openCalendlyOnBrowser = async () => {
+    await WebBrowser.openBrowserAsync(calendlyLink);
+  };
+
   return (
     <View style={screenStyles.text}>
       <Text>Schedule an appointment with your attorney!</Text>
+      <Button title="Open Calendly" onPress={openCalendlyOnBrowser} />
     </View>
   );
 };


### PR DESCRIPTION
# ✨ New in this PR ✨

## One liner: what did you do? 🚨 

Added a button to open a web browser with Team SIREN's calendly page on the Scheduling Tab. When an appointment is scheduled, a new document is created in Firebase. 

<img width="539" alt="Screen Shot 2021-10-28 at 8 42 26 PM" src="https://user-images.githubusercontent.com/55935661/139372079-e30a4cbf-9c42-491b-8505-e71667b4c46a.png">

<img width="539" alt="Screen Shot 2021-10-28 at 8 42 31 PM" src="https://user-images.githubusercontent.com/55935661/139372073-5a015042-1319-45f4-b01f-be3a6fc3d842.png">

## Coverage 🙆‍♀️
_use this section to break up your task into submodules and track progress_ 

## How can the reviewer test your code? 👩‍💻
_example: run `npm start` and click through Navigation bar_ 
Run the app and schedule an appointment!

## Any bugs you encountered or still having trouble with? 🐛
_describe how you solved them such that someone can follow your explanation_ 


## Resources 📔
_link online resources and related PRs_ 
https://docs.expo.dev/versions/latest/sdk/webbrowser/

🧜‍♀️ cc: @shannonbonet @phoebeli23
