### PR TITLE
fixed button styling and renamed auth folder

### DIFF
--- a/assets/Components.tsx
+++ b/assets/Components.tsx
@@ -3,14 +3,16 @@ import styled from 'styled-components/native';
 
 export const ButtonLight = styled.TouchableOpacity`
   text-align: center;
-  padding: 0.4em 1em;
+  align-items: center;
+  padding: 10px;
   border-width: 1px;
   border-radius: 5px;
 `;
 
 export const ButtonDark = styled.TouchableOpacity`
   text-align: center;
-  padding: 0.4em 1em;
+  align-items: center;
+  padding: 10px;
   border-width: 1px;
   border-radius: 5px;
   background: black;


### PR DESCRIPTION
# ✨ New in this PR ✨

## One liner: what did you do? 🚨 
Changed styling values to integers instead of strings that caused Android crashes 

Styling gotcha: React Native styling expects variables to be integer values, not string types. You might receive an error like 'Error while updating property 'X' in shadow node of type: RCTView'that causes the app to crash when testing on Android Emulator.

What this means and how to fix:
```
padding: 0.4em 1em -> padding: 4px 4px; // we cannot use em, vh, etc 
margin-vertical: '10px'; -> margin-vertical: 10px;
```


## Resources 📔
[overflow fix ](https://stackoverflow.com/questions/37571418/reactnative-how-to-center-text)


🧜‍♀️ cc: @shannonbonet @phoebeli23
