### PR TITLE
differentiate scroll container and (inner) non-centered page container

### DIFF
--- a/src/screens/styles.ts
+++ b/src/screens/styles.ts
@@ -8,7 +8,11 @@ export const PageContainer = styled.View`
   justify-content: center;
 `;
 
+// non-centered
 export const ScrollPageContainer = styled.ScrollView`
-  margin-vertical: 20px;
-  flex: 1;
+  overflow: scroll;
+`;
+
+export const InnerPageContainer = styled.View`
+  margin: 5%;
 `;


### PR DESCRIPTION
# ✨ New in this PR ✨

## One liner: what did you do? 🚨 
defines two new page containers for scrolling & non-centered, instead of both in one - this way the scrollbar doesn't have weird inner margins

## Coverage 🙆‍♀️
_use this section to break up your task into submodules and track progress_ 
 - [X] above

🧜‍♀️ cc: @shannonbonet @phoebeli23
