### PR TITLE
Shannon/status

### DIFF
--- a/src/components/DocContainer/DocContainer.tsx
+++ b/src/components/DocContainer/DocContainer.tsx
@@ -37,16 +37,18 @@ const DocContainer = ({
 
   console.log(clientId, clientCase.id);
 
+  // ERROR HERE. getStatus is not working for me.
   const status = getStatus(clientId, clientCase.id);
   console.log('status', status);
 
   const submitDocs = () => {
-    if (new Set(documents.map(doc => doc.type)).size === docList.length) {
-      setStatus(clientId, clientCase.id, CaseStatus.InReview);
-      return Submitted;
+    if (new Set(documents.map(doc => doc.type)).size !== docList.length) {
+      setStatus(clientId, clientCase.id, CaseStatus.SubmitDoc);
+      return Missing;
     }
-    setStatus(clientId, clientCase.id, CaseStatus.SubmitDoc);
-    return Missing;
+    // want to set status to whatever it was previously ...
+    setStatus(clientId, clientCase.id, CaseStatus.InReview);
+    return Submitted;
   };
 
   return (

--- a/src/components/DocContainer/DocContainer.tsx
+++ b/src/components/DocContainer/DocContainer.tsx
@@ -24,31 +24,39 @@ const DocContainer = ({
   navigation,
 }: ContainerProps) => {
   const [documents, setDocuments] = useState([] as Document[]);
+  const [status, setStat] = useState('');
 
   const populateDocuments = async () => {
     const currDocuments = await getAllDocuments(clientId, clientCase.id);
     setDocuments(currDocuments);
   };
 
+  console.log(documents);
+
+  // console.log(docList);
+
   const isFocused = useIsFocused();
   useEffect(() => {
     populateDocuments();
   }, [isFocused]);
 
-  console.log(clientId, clientCase.id);
+  const getClientStatus = async () => {
+    const currStat = await getStatus(clientId, clientCase.id);
+    setStat(currStat);
+  };
 
-  // ERROR HERE. getStatus is not working for me.
-  const status = getStatus(clientId, clientCase.id);
-  console.log('status', status);
+  getClientStatus();
 
   const submitDocs = () => {
+    if (new Set(documents.map(doc => doc.type)).size === docList.length) {
+      setStatus(clientId, clientCase.id, CaseStatus.InReview);
+      return Submitted;
+    }
     if (new Set(documents.map(doc => doc.type)).size !== docList.length) {
       setStatus(clientId, clientCase.id, CaseStatus.SubmitDoc);
       return Missing;
     }
-    // want to set status to whatever it was previously ...
-    setStatus(clientId, clientCase.id, CaseStatus.InReview);
-    return Submitted;
+    return null;
   };
 
   return (

--- a/src/components/DocContainer/DocContainer.tsx
+++ b/src/components/DocContainer/DocContainer.tsx
@@ -4,9 +4,9 @@ import DocHolder, {
   Submitted,
 } from 'components/DocContainer/DocHolder';
 import { TextBold } from 'assets/fonts/Fonts';
-import { Case, Document } from 'types/types';
+import { Case, CaseStatus, Document } from 'types/types';
 import { convertCamelToTitleCase } from 'utils/utils';
-import { getAllDocuments } from 'database/queries';
+import { getAllDocuments, getStatus, setStatus } from 'database/queries';
 import { useIsFocused } from '@react-navigation/native';
 import { Container, Header } from './styles';
 
@@ -35,12 +35,24 @@ const DocContainer = ({
     populateDocuments();
   }, [isFocused]);
 
+  console.log(clientId, clientCase.id);
+
+  const status = getStatus(clientId, clientCase.id);
+  console.log('status', status);
+
+  const submitDocs = () => {
+    if (new Set(documents.map(doc => doc.type)).size === docList.length) {
+      setStatus(clientId, clientCase.id, CaseStatus.InReview);
+      return Submitted;
+    }
+    setStatus(clientId, clientCase.id, CaseStatus.SubmitDoc);
+    return Missing;
+  };
+
   return (
     <Container>
       <Header>
-        {new Set(documents.map(doc => doc.type)).size === docList.length
-          ? Submitted
-          : Missing}
+        {submitDocs()}
         <TextBold> {convertCamelToTitleCase(clientCase.type)}</TextBold>
       </Header>
       {docList.map(name => (

--- a/src/components/ProgressTracker/ProgressTracker.tsx
+++ b/src/components/ProgressTracker/ProgressTracker.tsx
@@ -3,10 +3,11 @@ import { View } from 'react-native';
 import { ProgressSteps, ProgressStep } from 'react-native-progress-steps';
 import { Colors } from 'assets/Colors';
 import { TextBold, TextRegular } from 'assets/fonts/Fonts';
+import { convertCamelToTitleCase } from 'utils/utils';
 import { TitleContainer, MainContainer } from './styles';
 
 interface TrackerProps {
-  type: string | undefined;
+  type: string;
   status: string;
 }
 
@@ -26,7 +27,7 @@ const ProgressTracker = (props: TrackerProps) => {
   return (
     <MainContainer>
       <TitleContainer>
-        <TextBold>{type || null}</TextBold>
+        <TextBold>{convertCamelToTitleCase(type)}</TextBold>
       </TitleContainer>
       <ProgressSteps
         activeStep={statusDict[status]}

--- a/src/components/ProgressTracker/ProgressTracker.tsx
+++ b/src/components/ProgressTracker/ProgressTracker.tsx
@@ -3,43 +3,21 @@ import { View } from 'react-native';
 import { ProgressSteps, ProgressStep } from 'react-native-progress-steps';
 import { Colors } from 'assets/Colors';
 import { TextBold, TextRegular } from 'assets/fonts/Fonts';
-import { TitleContainer, TrackerContainer, MainContainer } from './styles';
+import { TitleContainer, MainContainer } from './styles';
 
 interface TrackerProps {
-  type: string;
+  type: string | undefined;
   status: string;
 }
 
-function setType(type: string) {
-  // TO DO: add additional case types. maybe refactor into dictionary
-  if (type === 'dacaRenewal') {
-    return 'DACA Renewal';
-  }
-  if (type === 'general') {
-    return 'Citizenship';
-  }
-  return null;
-}
-
-function setStep(status: string) {
-  // TO DO: Refactor into dictionary
-  if (status === 'submitForm') {
-    return 0;
-  }
-  if (status === 'submitDoc') {
-    return 1;
-  }
-  if (status === 'underRev') {
-    return 2;
-  }
-  if (status === 'schedApt') {
-    return 3;
-  }
-  if (status === 'aptSched') {
-    return 4;
-  }
-  return null;
-}
+const statusDict: { [key: string]: number } = {
+  // expecting CaseStatus value types
+  submitForm: 0,
+  submitDoc: 1,
+  inReview: 2,
+  schedApt: 3,
+  attenApt: 4,
+};
 
 const ProgressTracker = (props: TrackerProps) => {
   const { status } = props;
@@ -48,62 +26,58 @@ const ProgressTracker = (props: TrackerProps) => {
   return (
     <MainContainer>
       <TitleContainer>
-        <TextBold>{setType(type)}</TextBold>
+        <TextBold>{type || null}</TextBold>
       </TitleContainer>
-      <TrackerContainer>
-        <ProgressSteps
-          activeStep={setStep(status)}
-          borderWidth={1}
-          activeStepIconBorderColor={Colors.lightBlue}
-          progressBarColor={Colors.brandBlue}
-          completedProgressBarColor={Colors.brandBlue}
-          completedStepIconColor={Colors.lightBlue} // not sure if can make white w/ blue border
-          labelColor={Colors.brandGray}
-          labelFontSize={11}
-          activeLabelColor={Colors.brandGray}
-          completedLabelColor={Colors.brandGray}
-        >
-          <ProgressStep label="Intake" removeBtnRow scrollable={false}>
-            <View style={{ alignItems: 'center' }}>
-              <TextRegular>
-                Your intake form has been submitted for this case type.
-              </TextRegular>
-            </View>
-          </ProgressStep>
-          <ProgressStep label="Upload" removeBtnRow scrollable={false}>
-            <View style={{ alignItems: 'center' }}>
-              <TextRegular>
-                Please upload your legal documents so your case can be properly
-                assessed.
-              </TextRegular>
-            </View>
-          </ProgressStep>
-          <ProgressStep label="In review" removeBtnRow scrollable={false}>
-            <View style={{ alignItems: 'center' }}>
-              <TextRegular>
-                Your case is now under review. You will be notified of its
-                status soon.
-              </TextRegular>
-            </View>
-          </ProgressStep>
-          <ProgressStep label="Schedule" removeBtnRow scrollable={false}>
-            <View style={{ alignItems: 'center' }}>
-              <TextRegular>
-                Your case has been approved and you can now schedule an
-                appointment!
-              </TextRegular>
-            </View>
-          </ProgressStep>
-          <ProgressStep label="Attended" removeBtnRow scrollable={false}>
-            <View style={{ alignItems: 'center' }}>
-              <TextRegular>
-                You have met with your attorney! Wait to hear back from them
-                with any updates.
-              </TextRegular>
-            </View>
-          </ProgressStep>
-        </ProgressSteps>
-      </TrackerContainer>
+      <ProgressSteps
+        activeStep={statusDict[status]}
+        borderWidth={1}
+        activeStepIconBorderColor={Colors.lightBlue}
+        progressBarColor={Colors.brandBlue}
+        completedProgressBarColor={Colors.brandBlue}
+        completedStepIconColor={Colors.lightBlue} // not sure if can make white w/ blue border
+        labelColor={Colors.brandGray}
+        labelFontSize={11}
+        activeLabelColor={Colors.brandGray}
+        completedLabelColor={Colors.brandGray}
+      >
+        <ProgressStep label="Intake" removeBtnRow scrollable={false}>
+          <View style={{ alignItems: 'center' }}>
+            <TextRegular>Please submit an intake form.</TextRegular>
+          </View>
+        </ProgressStep>
+        <ProgressStep label="Upload" removeBtnRow scrollable={false}>
+          <View style={{ alignItems: 'center' }}>
+            <TextRegular>
+              Please upload your legal documents so your case can be properly
+              assessed.
+            </TextRegular>
+          </View>
+        </ProgressStep>
+        <ProgressStep label="In review" removeBtnRow scrollable={false}>
+          <View style={{ alignItems: 'center' }}>
+            <TextRegular>
+              Your case is now under review. You will be notified of its status
+              soon.
+            </TextRegular>
+          </View>
+        </ProgressStep>
+        <ProgressStep label="Schedule" removeBtnRow scrollable={false}>
+          <View style={{ alignItems: 'center' }}>
+            <TextRegular>
+              Your case has been approved and you can now schedule an
+              appointment!
+            </TextRegular>
+          </View>
+        </ProgressStep>
+        <ProgressStep label="Attended" removeBtnRow scrollable={false}>
+          <View style={{ alignItems: 'center' }}>
+            <TextRegular>
+              You have met with your attorney! Wait to hear back from them with
+              any updates.
+            </TextRegular>
+          </View>
+        </ProgressStep>
+      </ProgressSteps>
     </MainContainer>
   );
 };

--- a/src/components/ProgressTracker/styles.ts
+++ b/src/components/ProgressTracker/styles.ts
@@ -5,11 +5,12 @@ import { Colors } from 'assets/Colors';
 export const MainContainer = styled.View`
   display: flex;
   align-items: center;
-  width: 346px;
+  width: 100%;
   border-width: 1px;
   border-radius: 8px;
   border-color: ${Colors.borderGray};
   background-color: ${Colors.white};
+  padding: 20px;
   margin-bottom: 16px;
 `;
 
@@ -18,9 +19,4 @@ export const TitleContainer = styled.View`
   align-items: center;
   top: 20px;
   margin-bottom: 12px;
-`;
-
-export const TrackerContainer = styled.View`
-  width:288px;
-  margin-bottom: 20px;
 `;

--- a/src/database/queries.tsx
+++ b/src/database/queries.tsx
@@ -12,6 +12,7 @@ import {
 } from 'types/types';
 import firebase from 'database/clientApp';
 import { objectToMap, mapToObject, firestoreAutoId } from 'database/helpers';
+import { register } from './auth';
 
 const database = firebase.firestore();
 const clientCollection = database.collection('clients');
@@ -392,7 +393,6 @@ export const setStatus = async (
   }
 };
 
-// cannot get this function to work, keeps returning Promise
 export const getStatus = async (
   clientId: string,
   caseId: string,
@@ -402,8 +402,8 @@ export const getStatus = async (
       .collection(`clients/${clientId}/cases`)
       .doc(caseId)
       .get();
-    return ref.data()?.status as string;
-    // also tried https://www.reddit.com/r/Firebase/comments/gyasun/how_can_we_access_a_field_within_a_document_in/
+    const status = await ref.data()?.status;
+    return status;
   } catch (e) {
     console.warn(e);
     throw e;

--- a/src/database/queries.tsx
+++ b/src/database/queries.tsx
@@ -375,3 +375,28 @@ export const setCaseAndNumCases = async (
     throw e;
   }
 };
+
+// export const getStatus = async () => {
+//   try {
+//     const status =
+//   } catch (e) {
+//     console.warn(e);
+//     throw e;
+//   }
+// };
+
+export const setStatus = async (
+  clientId: string,
+  caseId: string,
+  clientStatus: CaseStatus,
+) => {
+  try {
+    await database
+      .collection(`clients/${clientId}/cases/${caseId}`)
+      .doc(caseId)
+      .update({ status: clientStatus });
+  } catch (e) {
+    console.warn(e);
+    throw e;
+  }
+};

--- a/src/database/queries.tsx
+++ b/src/database/queries.tsx
@@ -12,7 +12,6 @@ import {
 } from 'types/types';
 import firebase from 'database/clientApp';
 import { objectToMap, mapToObject, firestoreAutoId } from 'database/helpers';
-import { register } from './auth';
 
 const database = firebase.firestore();
 const clientCollection = database.collection('clients');

--- a/src/database/queries.tsx
+++ b/src/database/queries.tsx
@@ -392,6 +392,7 @@ export const setStatus = async (
   }
 };
 
+// cannot get this function to work, keeps returning Promise
 export const getStatus = async (
   clientId: string,
   caseId: string,
@@ -400,9 +401,8 @@ export const getStatus = async (
     const ref = await database
       .collection(`clients/${clientId}/cases`)
       .doc(caseId)
-      .get()
-      .then(doc => doc.get('status'));
-    return ref;
+      .get();
+    return ref.data()?.status as string;
   } catch (e) {
     console.warn(e);
     throw e;

--- a/src/database/queries.tsx
+++ b/src/database/queries.tsx
@@ -403,6 +403,7 @@ export const getStatus = async (
       .doc(caseId)
       .get();
     return ref.data()?.status as string;
+    // also tried https://www.reddit.com/r/Firebase/comments/gyasun/how_can_we_access_a_field_within_a_document_in/
   } catch (e) {
     console.warn(e);
     throw e;

--- a/src/database/queries.tsx
+++ b/src/database/queries.tsx
@@ -376,15 +376,6 @@ export const setCaseAndNumCases = async (
   }
 };
 
-// export const getStatus = async () => {
-//   try {
-//     const status =
-//   } catch (e) {
-//     console.warn(e);
-//     throw e;
-//   }
-// };
-
 export const setStatus = async (
   clientId: string,
   caseId: string,
@@ -392,9 +383,26 @@ export const setStatus = async (
 ) => {
   try {
     await database
-      .collection(`clients/${clientId}/cases/${caseId}`)
+      .collection(`clients/${clientId}/cases`)
       .doc(caseId)
       .update({ status: clientStatus });
+  } catch (e) {
+    console.warn(e);
+    throw e;
+  }
+};
+
+export const getStatus = async (
+  clientId: string,
+  caseId: string,
+): Promise<string> => {
+  try {
+    const ref = await database
+      .collection(`clients/${clientId}/cases`)
+      .doc(caseId)
+      .get()
+      .then(doc => doc.get('status'));
+    return ref;
   } catch (e) {
     console.warn(e);
     throw e;

--- a/src/screens/Home/HomeScreen.tsx
+++ b/src/screens/Home/HomeScreen.tsx
@@ -4,7 +4,7 @@ import { ScrollView } from 'react-native';
 import { TextTitle } from 'assets/fonts/Fonts';
 import { NameContainer, PageContainer } from 'screens/styles';
 import { getAllCases, getClient } from 'database/queries';
-import { Case } from 'types/types';
+import { Case, CaseStatus } from 'types/types';
 import firebase from 'firebase';
 import ProgressTracker from 'components/ProgressTracker/ProgressTracker';
 
@@ -35,13 +35,22 @@ const HomeScreen = ({ navigation }: any) => {
         <TextTitle>Hi {name}!</TextTitle>
       </NameContainer>
       <ScrollView>
-        {Object.keys(cases).map((id: any) => (
+        {cases.length !== 0 ? (
+          Object.keys(cases).map((id: any) => (
+            <ProgressTracker
+              key={id}
+              type={cases[id].type}
+              status={cases[id].status}
+            />
+          ))
+        ) : (
           <ProgressTracker
-            key={id}
-            type={cases[id].type}
-            status={cases[id].status}
+            key="id"
+            type={undefined} // yes, bad
+            status={CaseStatus.SubmitForm} // default case status
+            // Under the hood, an official case & its status isn't !exist in Firebase until client submits intake form
           />
-        ))}
+        )}
       </ScrollView>
     </PageContainer>
   );

--- a/src/screens/Home/HomeScreen.tsx
+++ b/src/screens/Home/HomeScreen.tsx
@@ -46,7 +46,7 @@ const HomeScreen = ({ navigation }: any) => {
         ) : (
           <ProgressTracker
             key="id"
-            type={undefined} // yes, bad
+            type="No Cases Yet" // yes, bad
             status={CaseStatus.SubmitForm} // default case status
             // Under the hood, an official case & its status isn't !exist in Firebase until client submits intake form
           />

--- a/src/screens/Schedule/ScheduleScreen.tsx
+++ b/src/screens/Schedule/ScheduleScreen.tsx
@@ -56,6 +56,8 @@ const ScheduleScreen = () => {
           .filter(c => c.status === CaseStatus.SchedApt)
           .map(c => c.type);
 
+        // console.log(clientCaseTypes);
+
         // fetch all calendly links
         Promise.all(
           clientCaseTypes.map(caseType => getCalendlyLink(caseType)),
@@ -63,6 +65,8 @@ const ScheduleScreen = () => {
 
         // fetch all uncancelled appointments for client
         const appts = await getAllUpcomingAppointmentsForClient(client);
+        // console.log('appointments', appts);
+
         setAppointments(appts);
         if (appts.length !== 0) {
           setSwitchPage(1);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,7 +1,9 @@
 export enum CaseStatus {
   SubmitForm = 'submitForm',
   SubmitDoc = 'submitDoc',
+  InReview = 'inReview',
   SchedApt = 'schedApt',
+  AttenApt = 'attenApt',
 }
 export enum QuestionType {
   General = 'general',


### PR DESCRIPTION
# ✨ get/set Client status ✨

## Coverage 🙆‍♀️
_use this section to break up your task into submodules and track progress_ 
 - [X] Refactored progress tracker to use CaseTypes instead of hardcode 
 - [X]  set default status to intake form stage upon login 
 - [X] setStatus query
 - [x] getStatus query
 - [X] update status after intake form submit
 - [ ] update status after schedule appointment (**blocked by zapier set up, defer to next PR**) realizing that this is changed from the web's end

## How can the reviewer test your code? 👩‍💻
run `npm start` 

## Any bugs you encountered or still having trouble with? 🐛
2 main bugs: 
**[SOLVED]** - turns out I wasn't using `async/await` functions. [See SIREN Firebase documentation 101](https://www.notion.so/calblueprint/SIREN-Firebase-101-781a32317d3e4b89b912fba4e1a1c75c#b97b3f418d7843bfb1c076665848a063)

1. When trying to setStatus after submitting documents, code only checks for equivalent length between given doclist + submitted docs. This means it resets the status every time I navigate to the upload page. So, I also want to check that the current status is **not already** inReview. Hence, the getStatus query but it doesn't woooorkkk :((((

**NOTICED BUG**
2. calendar feature does not pull upcoming appointments in... this is really strange. will look in more tomorrow. It might have something to do with the caseType refactor. 


## Resources 📔
- https://www.reddit.com/r/Firebase/comments/gyasun/how_can_we_access_a_field_within_a_document_in/ 


🧜‍♀️ cc: @whuang7000 @bry-gavino @j-keating0002 
